### PR TITLE
feat/fix:增加後臺頁面功能 / 調整首頁UI

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_API=https://vue3-course-api.hexschool.io/v2
+VITE_PATH=whatstoday2024

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "deploy": "vite build && gh-pages -d dist"
   },
   "dependencies": {
+    "@element-plus/icons-vue": "^2.3.1",
     "@popperjs/core": "^2.11.8",
     "@vee-validate/i18n": "^4.12.5",
     "@vee-validate/rules": "^4.12.5",
@@ -23,7 +24,9 @@
     "vee-validate": "^4.12.5",
     "vue": "^3.4.15",
     "vue-loading-overlay": "6.0",
-    "vue-router": "^4.2.5"
+    "vue-router": "^4.2.5",
+    "vue-star-rating": "^2.1.0",
+    "vue3-toastify": "^0.2.1"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.3.3",

--- a/src/components/FooterComponent/index.vue
+++ b/src/components/FooterComponent/index.vue
@@ -3,13 +3,13 @@
     <div class="row mx-auto py-4" style="width: 90%">
       <div
         class="order-2 order-md-1 col-12 col-md-6 align-items-center align-items-md-start d-flex flex-column justify-content-center gap-3">
-        <router-link class="logo d-none d-md-block" to="/"><img alt="logo" :src="logo" />
-        </router-link>
+        <RouterLink to="/" class="logo d-none d-md-block"><img alt="logo" :src="logo" />
+        </RouterLink>
         <div class="text-center text-md-start">
           <a class="text-white" href="mailto:whatstoday2024@gmail.com">
             <h6>whatstoday2024@gmail.com</h6>
           </a>
-          <h6 class="text-white">&copy;whatstoday2024 2024. All rights reserved.</h6>
+          <h6 class="text-white">&copy;whatstoday2024. All rights reserved.</h6>
         </div>
       </div>
       <div

--- a/src/components/Pagination/index.vue
+++ b/src/components/Pagination/index.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="pagination">
+    <div class='page-item' :class="{'active': page === currentPage}" v-for="(page,index) in totalPages" :key="index">
+          <button  class="page-link"
+                  :key="index"
+                  @click="goToPage(page)"
+                  >
+              {{ page }}
+          </button>
+      </div>
+  </div>
+</template>
+
+<script>
+
+
+export default {
+  props: ["totalPages", "currentPage"],
+
+  setup(props, { emit }) {
+    const goToPage = (toPage) => {
+      emit("goToPage", toPage);
+    };
+
+    return { goToPage };
+  },
+  data() {
+    return {
+    
+    }
+  },
+  methods: {
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.pagination{
+  margin-top: 2rem;
+  display: flex;
+  justify-content: center;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import Vue3Toastify, { toast } from 'vue3-toastify';
 
 import App from './App.vue'
 import router from './router'
 
-
+import 'bootstrap/dist/js/bootstrap.bundle.min.js'
 import '@/scss/all.scss'
 
 import * as VeeValidate from 'vee-validate'
@@ -23,6 +24,10 @@ VeeValidateI18n.setLocale('zh_TW')
 
 const app = createApp(App)
 
+app.use(Vue3Toastify, {
+  autoClose: 1000, //自動關閉時間
+  position: toast.POSITION.TOP_CENTER //提示窗位置
+})
 app.use(createPinia())
 app.use(router)
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,7 +18,12 @@ const router = createRouter({
           path: 'admin',
           name: 'adminLayout',
           component: () => import('@/views/AdminLayout'),
-          children: []
+          children: [
+              { path: '', name: 'AdminLogin', component: () => import('@/views/AdminLayout/AdminLogin') },
+              { path: 'admin-items', name: 'AdminItems', component: () => import('@/views/AdminLayout/AdminItems') },
+              { path: 'add-item', name: 'AddItem', component: () => import('@/views/AdminLayout/AddItem') },
+              { path: 'edit-item/:id', name: 'Login', component: () => import('@/views/AdminLayout/EditItem') },
+          ]
         }
       ]
     }

--- a/src/utils/variables.js
+++ b/src/utils/variables.js
@@ -21,31 +21,31 @@ export const QAs = [
     id: 1,
     title: '營養比例是什麼 ?',
     content:
-      '我們提供了預設與自訂模式，不論您想快速開始體驗，或是想打造個人化的選菜系統，在這裡您都能得到滿足。'
+      '我們會盡力讓生成的便當菜色的澱粉比例:蛋白質比例:蔬菜比例符合 1:1:2 讓您慢慢地改善飲食習慣。'
   },
   {
     id: 3,
     title: '菜色健康分數是什麼 ?',
     content:
-      '我們提供了預設與自訂模式，不論您想快速開始體驗，或是想打造個人化的選菜系統，在這裡您都能得到滿足。'
+      '依照原料、料理方式、營養價值等，估算出菜色的健康分數，1分為最差，5分為最好，以0.5分為間距。'
   },
   {
     id: 4,
     title: '放縱日是什麼 ? 如何設定放縱日 ?',
     content:
-      '我們提供了預設與自訂模式，不論您想快速開始體驗，或是想打造個人化的選菜系統，在這裡您都能得到滿足。'
+      '不在意營養比例與健康分數，純粹以您的偏好分數進行配菜(此功能加入會員即可使用)。'
   },
   {
     id: 5,
     title: '每次使用都需要重新設定嗎 ?',
     content:
-      '我們提供了預設與自訂模式，不論您想快速開始體驗，或是想打造個人化的選菜系統，在這裡您都能得到滿足。'
+      '即使不登入會員也不需要重複設定，每個裝置只有首次使用時須要做偏好設置。'
   },
   {
     id: 6,
     title: '不同裝置間可以保存，取用紀錄嗎 ?',
     content:
-      '我們提供了預設與自訂模式，不論您想快速開始體驗，或是想打造個人化的選菜系統，在這裡您都能得到滿足。'
+      '只要加入會員，我們可以為您保存飲食紀錄，並隨時取用。'
   }
 ]
 
@@ -55,7 +55,7 @@ export const memberOptions = [
     icon: icon1,
     title: '跨裝置存取',
     content1: '只要加入會員',
-    content2: '讓我們保存您的飲食紀錄',
+    content2: '我們將保存您的飲食紀錄',
     content3: '不用擔心切換裝置'
   },
   {
@@ -63,15 +63,15 @@ export const memberOptions = [
     icon: icon2,
     title: '便當日記系統',
     content1: '專屬個人的月曆',
-    content2: '紀錄您每一天的菜色',
+    content2: '記錄您每一天的菜色',
     content3: '更清楚知道您每天吃了些什麼'
   },
   {
     id: uuidv4(),
     icon: icon3,
     title: '許願菜色',
-    content1: '想吃得菜色不在列表中 ?',
-    content2: '透過許願單向我們提議新菜色吧 !'
+    content1: '想吃的菜色不在列表中 ?',
+    content2: '透過許願表單向我們提議新菜色吧 !'
   },
   {
     id: uuidv4(),
@@ -89,7 +89,7 @@ export const provideOptions = [
     icon: icon5,
     title: '菜色拉霸',
     content:
-      '我們提供了一種拉霸式的視覺化功能，只需輕觸一下，即可生成出完整的便當。此外，還有自選菜色及喜好度紀錄功能，打造您個人化的選菜系統。'
+      '我們提供了一種拉霸式的視覺化功能，只需輕觸一下，即可生成出完整的便當。此外，還有自選菜色及喜好度記錄功能，打造您個人化的選菜系統。'
   },
   {
     id: uuidv4(),
@@ -103,6 +103,376 @@ export const provideOptions = [
     icon: icon7,
     title: '專屬便當日記(會員限定)',
     content:
-      '打造您專屬的個人飲食月曆功能，紀錄您每一天所挑選的菜色，未來將不用再努力回想您吃了些什麼，在這裡您可以隨時查詢飲食紀錄。'
+      '打造您專屬的個人飲食月曆功能，記錄您每一天所挑選的菜色，未來將不用再努力回想您吃了些什麼，在這裡您可以隨時查詢飲食紀錄。'
   }
+]
+
+export const items= [
+  {
+    id: uuidv4(),
+    title: "炒高麗菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    imgUrl: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    images:[
+      "https://res.cloudinary.com/dfvtounam/image/upload/v1707713396/-_Pan-fried_Sausage_mjczxu.png",
+      "https://res.cloudinary.com/dfvtounam/image/upload/v1707713522/%E7%A7%8B%E8%91%B5_aip9qo.jpg"
+    ],
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類", 
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒花椰菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+  {
+    id: uuidv4(),
+    title: "炒清江菜",
+    engTitle: "Stir-Fried Cauliflower",
+    category: "配菜類",
+    healthLevel: "4.5",
+    starchPortion: "0",
+    proteinPortion: "0.25",
+    vegetablePortion: "0.25",
+    img: "https://res.cloudinary.com/dfvtounam/image/upload/v1707713425/-_Stir-Fried_Cauliflower_ibhm07.jpg",
+    noBgImg: ""
+  },
+
+
+
 ]

--- a/src/views/AdminLayout/AddItem/index.vue
+++ b/src/views/AdminLayout/AddItem/index.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="container my-5">
+    <div class="text-start mb-4 d-flex justify-content-between border-bottom pb-3">
+      <h3>新增菜色</h3>
+      <button class="btn btn-outline-brand-blue">
+        <RouterLink class="navbar-brand" to="/admin/admin-items">
+          菜色列表
+        </RouterLink>
+      </button>
+    </div>
+    <VForm class="row" v-slot="{ errors }" @submit="addItem" >
+    <div class="p-2 p-lg-3 col-md-6">
+      <div>
+        <h5>菜色名稱 / 分類 / 健康分數</h5>
+        <div class="form-floating mb-4">
+          <VField type="text" id="title" placeholder="請輸入菜色名稱" name="title" class="form-control" :class="{ 'is-invalid': errors['title'] }" rules="required" v-model="item.title" />
+            <ErrorMessage name="title" class="invalid-feedback"/>
+            <label for="title">中文名稱*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField type="text" id="engTitle" placeholder="請輸入英文名稱" name="engTitle" class="form-control" :class="{ 'is-invalid': errors['engTitle'] }" rules="required" v-model="item.engTitle" />
+            <ErrorMessage name="engTitle" class="invalid-feedback"/>
+            <label for="engTitle">英文名稱*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="category" placeholder="請選擇分類" name="category" class="form-select" :class="{ 'is-invalid': errors['category'] }" rules="required" v-model="item.category">
+            <option value="主食類">主食類</option>
+            <option value="配菜類">配菜類</option>
+            <option value="主菜類">主菜類</option>
+          </VField>
+            <ErrorMessage name="category" class="invalid-feedback"/>
+            <label for="category">分類*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="healthLevel" placeholder="請選擇健康分數" name="healthLevel" class="form-select" :class="{ 'is-invalid': errors['healthLevel'] }" rules="required" v-model="item.healthLevel">
+            <option value="1">1</option>
+            <option value="1.5">1.5</option>
+            <option value="2">2</option>
+            <option value="2.5">2.5</option>
+            <option value="3">3</option>
+            <option value="3.5">3.5</option>  
+            <option value="4">4</option>  
+            <option value="4.5">4.5</option>
+            <option value="5">5</option>   
+          </VField>
+            <ErrorMessage name="healthLevel" class="invalid-feedback"/>
+            <label for="healthLevel">健康分數*</label>
+        </div>
+      </div>
+      <div>
+        <h5>營養比例(份)</h5>
+        <div class="form-floating mb-4">
+          <VField as="select" id="starchPortion" placeholder="請選擇澱粉比例" name="starchPortion" class="form-select" :class="{ 'is-invalid': errors['starchPortion'] }" rules="required" v-model="item.starchPortion">
+            <option value="0">0</option>
+            <option value="0.25">0.25</option>
+            <option value="0.33">0.33</option>
+            <option value="0.66">0.66</option>
+            <option value="0.75">0.75</option>
+            <option value="1">1</option>     
+          </VField>
+            <ErrorMessage name="starchPortion" class="invalid-feedback"/>
+            <label for="starchPortion">澱粉比例*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="proteinPortion" placeholder="請選擇蛋白質比例" name="proteinPortion" class="form-select" :class="{ 'is-invalid': errors['proteinPortion'] }" rules="required" v-model="item.proteinPortion">
+            <option value="0">0</option>
+            <option value="0.25">0.25</option>
+            <option value="0.33">0.33</option>
+            <option value="0.66">0.66</option>
+            <option value="0.75">0.75</option>
+            <option value="1">1</option>   
+          </VField>
+            <ErrorMessage name="proteinPortion" class="invalid-feedback"/>
+            <label for="proteinPortion">蛋白質比例*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="vegetablePortion" placeholder="請選擇蔬菜比例" name="vegetablePortion" class="form-select" :class="{ 'is-invalid': errors['vegetablePortion'] }" rules="required" v-model="item.vegetablePortion">
+            <option value="0">0</option>
+            <option value="0.25">0.25</option>
+            <option value="0.33">0.33</option>
+            <option value="0.66">0.66</option>
+            <option value="0.75">0.75</option>
+            <option value="1">1</option>    
+          </VField>
+            <ErrorMessage name="vegetablePortion" class="invalid-feedback"/>
+            <label for="vegetablePortion">蔬菜比例*</label>
+        </div>
+      </div>
+    </div>
+    <div class="p-2 p-lg-3 col-md-6">
+      <div>
+        <h5>菜色圖片</h5>
+        <form id="upload-image" class="mb-2" action="/api/whatstoday2024/admin/upload" enctype="multipart/form-data" method="post">
+          <label for="formFile" class="form-label">上傳圖片</label>
+          <input ref="input-file" class="form-control" type="file" id="file-input" name="file-to-upload" @change="uploadImg">
+          <!-- <input type="submit" value="送出" @click.prevent="uploadImg"> -->
+          <img v-if="tempImg1 !==''" class="img" :src="tempImg1" alt="image">
+          <button v-if="tempImg1 !== ''" type="button" @click="addImage1" class="mt-2 btn btn-outline-brand-blue btn-sm">新增此圖片至圖片列表</button>
+        </form>
+      </div>
+      <div>
+        <div class="form-floating mb-4">
+          <div class="form-group mb-3">
+            <label for="imgUrl" class="form-label">圖片網址</label>
+              <input id="imgUrl" v-model="tempImg2" type="text" class="form-control" placeholder="請輸入圖片連結">
+              <img v-if="tempImg2 !==''" class="img" :src="tempImg2" alt="image">
+              <button v-if="tempImg2 !== ''" type="button" @click="addImage2" class="mt-2 btn btn-outline-brand-blue btn-sm">新增此圖片至圖片列表</button>
+          </div>
+        </div> 
+      </div>
+      <div>
+        <div class="mb-3">
+          <span>主圖*</span><span class="errorMsg">{{ errorMsg }}</span>
+          <div v-if="item.imgUrl">
+            <img class="img" :src="item.imgUrl" alt="image">
+          </div>
+        </div>
+        <div mb-3>
+          <span>圖片列表(點選<ElSelect style="width: 20px; height: 20px ;color:yellow;"/>成為主圖 / <DeleteFilled style="width: 20px; height: 20px ;color:black;"/>刪除圖片)</span>
+          <div v-if="item.images.length" class="img-box">
+            <div v-for="(img,index) in item.images" :key="index" style="position: relative;">
+              <img class="img" :src="img" alt="image">
+              <span @click="chooseMainImg(img)"><ElSelect style="width: 30px; height: 30px ;color:yellow; position: absolute; top: 1; left: 1;cursor: pointer;"/></span>
+              <span @click="deleteImg(index)"><DeleteFilled style="width: 30px; height: 30px ;color:#d4d4d4; position: absolute; top: 1; right: 1;cursor: pointer;"/></span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="d-flex gap-2 mt-3 btn-container">
+        <button type="submit" class="btn btn-brand-blue btn-md mb-4">確認</button>
+        <button type="button" @click="reset" class="btn btn-outline-grey66 btn-md mb-4">重置</button>
+      </div>
+      
+    </div>
+        
+    </VForm>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+import { toast } from 'vue3-toastify';
+import { DeleteFilled } from "@element-plus/icons-vue";
+import { Select as ElSelect } from "@element-plus/icons-vue";
+export default {
+  data() {
+    return {
+      item: {
+        title: '',
+        engTitle: '',
+        category:'',
+        healthLevel:'',
+        starchPortion: '',
+        proteinPortion: '',
+        vegetablePortion: '',
+        imgUrl: '',
+        images:[],
+        noBgImg: ''
+      },
+      tempImg1:'',
+      tempImg2:'',
+      errorMsg:'',
+    }
+  },
+  components: {
+    DeleteFilled,
+    ElSelect
+  },
+  methods: {
+    uploadImg() {
+        const form = document.querySelector('#upload-image');
+        const imageInput = document.querySelector("#file-input");
+        const formData = new FormData(form);
+        if (imageInput.value) {
+            // 取出 Token
+            const token = document.cookie.replace(/(?:(?:^|.*;\s*)token\s*=\s*([^;]*).*$)|^.*$/, '$1');
+            axios.defaults.headers.common.Authorization = token;
+            axios.post(`${import.meta.env.VITE_API}/api/${import.meta.env.VITE_PATH}/admin/upload`, formData)
+                .then((res) => {
+                    this.tempImg1 = res.data.imageUrl;
+                    imageInput.value = '';
+                    axios.defaults.headers.common.Authorization = null;
+                })
+                .catch(err => {
+                    toast.error(err.data.message);
+                    axios.defaults.headers.common.Authorization = null;
+                })
+        } else {
+            alert("請先選擇欲上傳之圖片。");
+        }
+    },
+    async addItem(){
+      if(this.item.imgUrl === ''){
+        this.errorMsg = '主圖為必填'
+        return
+      }
+      try{
+        const res = await axios.post(`http://localhost:3000/items`,this.item)
+        toast.success(`成功新增 ${res.data.title}`)
+        this.$router.push(`/admin/admin-items`);
+      }catch(err){
+        toast.error(err.data.message)
+      }
+    
+    },
+    reset(){
+      this.item = {title: '',
+        engTitle: '',
+        category:'',
+        healthLevel:'',
+        starchPortion: '',
+        proteinPortion: '',
+        vegetablePortion: '',
+        imgUrl: '',
+        images:[],
+        noBgImg: ''}
+    },
+    addImage1(){
+      this.item.images.push(this.tempImg1)
+      this.tempImg1 = ''
+    },
+    addImage2(){
+      this.item.images.push(this.tempImg2)
+      this.tempImg2 = ''
+    },
+    chooseMainImg(img){
+      this.item.imgUrl = img
+    },
+    deleteImg(index){
+      this.item.images.splice(index,1)
+    }
+  },
+  watch:{
+    'item.imgUrl':function(){
+      this.errorMsg = ''
+    },
+  },
+  mounted() {
+
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.img-box{
+  display: flex;
+}
+.img{
+  width: 12rem;
+}
+
+.container{
+  position: relative;
+}
+.btn-container{
+  position: absolute;
+  top: 3.5rem;
+  right: 0.8rem;
+}
+.errorMsg{
+  color: $brand-red;
+  font-size: 0.9rem;
+  margin-left: 1rem;
+}
+</style>

--- a/src/views/AdminLayout/AddItem/index.vue
+++ b/src/views/AdminLayout/AddItem/index.vue
@@ -51,36 +51,21 @@
         <h5>營養比例(份)</h5>
         <div class="form-floating mb-4">
           <VField as="select" id="starchPortion" placeholder="請選擇澱粉比例" name="starchPortion" class="form-select" :class="{ 'is-invalid': errors['starchPortion'] }" rules="required" v-model="item.starchPortion">
-            <option value="0">0</option>
-            <option value="0.25">0.25</option>
-            <option value="0.33">0.33</option>
-            <option value="0.66">0.66</option>
-            <option value="0.75">0.75</option>
-            <option value="1">1</option>     
+            <option v-for="item in portionOptions" :value="item" :key="item">{{item}}</option>     
           </VField>
             <ErrorMessage name="starchPortion" class="invalid-feedback"/>
             <label for="starchPortion">澱粉比例*</label>
         </div>
         <div class="form-floating mb-4">
           <VField as="select" id="proteinPortion" placeholder="請選擇蛋白質比例" name="proteinPortion" class="form-select" :class="{ 'is-invalid': errors['proteinPortion'] }" rules="required" v-model="item.proteinPortion">
-            <option value="0">0</option>
-            <option value="0.25">0.25</option>
-            <option value="0.33">0.33</option>
-            <option value="0.66">0.66</option>
-            <option value="0.75">0.75</option>
-            <option value="1">1</option>   
+            <option v-for="item in portionOptions" :value="item" :key="item">{{item}}</option>   
           </VField>
             <ErrorMessage name="proteinPortion" class="invalid-feedback"/>
             <label for="proteinPortion">蛋白質比例*</label>
         </div>
         <div class="form-floating mb-4">
           <VField as="select" id="vegetablePortion" placeholder="請選擇蔬菜比例" name="vegetablePortion" class="form-select" :class="{ 'is-invalid': errors['vegetablePortion'] }" rules="required" v-model="item.vegetablePortion">
-            <option value="0">0</option>
-            <option value="0.25">0.25</option>
-            <option value="0.33">0.33</option>
-            <option value="0.66">0.66</option>
-            <option value="0.75">0.75</option>
-            <option value="1">1</option>    
+            <option v-for="item in portionOptions" :value="item" :key="item">{{item}}</option>  
           </VField>
             <ErrorMessage name="vegetablePortion" class="invalid-feedback"/>
             <label for="vegetablePortion">蔬菜比例*</label>
@@ -145,6 +130,7 @@ import { Select as ElSelect } from "@element-plus/icons-vue";
 export default {
   data() {
     return {
+      portionOptions:[0,0.25,0.5,0.75,1,1.25,1.5,1.75,2,2.25,2.5,2.75,3,3.25,3.5,3.75,4,4.25,4.5,4.75,5],
       item: {
         title: '',
         engTitle: '',

--- a/src/views/AdminLayout/AdminItems/index.vue
+++ b/src/views/AdminLayout/AdminItems/index.vue
@@ -1,0 +1,119 @@
+<template>
+  <section class="container my-5 text-center">
+    <div class="text-start mb-5 d-flex justify-content-between">
+      <h3>菜色列表</h3>
+      <button class="btn btn-outline-brand-blue">
+        <RouterLink class="navbar-brand" to="/admin/add-item">
+          新增菜色
+        </RouterLink>
+      </button>
+    </div>
+    <table class="table align-middle">
+      <thead>
+        <tr>
+          <th scope="col">中文名稱</th>
+          <th scope="col">英文名稱</th>
+          <th scope="col">分類</th>
+          <th scope="col">健康分數</th>   
+          <th scope="col">澱粉 / 蛋白質 / 蔬菜</th>   
+          <th scope="col"></th>   
+          <th scope="col"></th>    
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="item in items" :key="item.id">
+          <th scope="row">{{ item.title }}</th>
+            <td>{{ item.engTitle }}</td>
+            <td>{{ item.category }}</td>
+            <td class="d-none d-md-block star">
+              <star-rating
+                :inline="true"
+                :star-size="25"
+                :read-only="true"
+                :rating="+item.healthLevel"
+                :round-start-rating="false"
+                :show-rating="false"
+                />
+            </td>
+            <td class="d-md-none">{{ item.healthLevel }}</td>
+
+            <td>{{ item.starchPortion }} / {{ item.proteinPortion }} / {{ item.vegetablePortion }}</td>
+            <td><button @click="goToItem(item.id)" type="button" class="btn btn-brand-blue">編輯</button></td>
+            <td><button @click="showDeleteItemModal(item.id)" type="button" class="btn btn-outline-danger">刪除</button></td>
+        </tr>
+      </tbody>
+    </table>
+    <Pagination
+            :currentPage="currentPage"
+            :totalPages="totalPages"
+            @goToPage="getItems"
+    ></Pagination>
+    <DeleteItemModal ref="deleteItemModal" :item="item" @deleteItem="deleteItem"/>
+  </section>
+</template>
+
+<script>
+import { toast } from 'vue3-toastify';
+import 'vue3-toastify/dist/index.css';
+import StarRating from 'vue-star-rating'
+import DeleteItemModal from '@/views/AdminLayout/DeleteItemModal'
+import axios from 'axios'
+
+import Pagination from '@/components/Pagination'
+
+export default {
+  data() {
+    return {
+      items:[],
+      item: {},
+      currentPage:'',
+      totalPages:''
+    }
+  },
+  components: {
+    DeleteItemModal,
+    StarRating,
+    Pagination
+  },
+  methods: {
+    goToItem(id){
+      this.$router.push(`/admin/edit-item/${id}`);
+    },
+    showDeleteItemModal(id){
+      const item = this.items.find(it=>it.id === id)
+      this.item = item
+      this.$refs.deleteItemModal.openModal();
+    },
+    async deleteItem(id){
+      try{
+        const res = await axios.delete(`http://localhost:3000/items/${id}`)
+        toast.success(`成功刪除 ${res.data.title}`)
+        await this.getItems()
+      }catch(err){
+        toast.error(err.data.message)
+      }
+
+
+    },
+    async getItems(toPage = 1){
+      this.currentPage = toPage
+      const res = await axios.get(`http://localhost:3000/items?_page=${toPage}`)
+      this.totalPages = Math.ceil(res.data.items / 10) 
+      this.items = res.data.data
+    }
+  },
+  async mounted() {
+    await this.getItems()
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.star{
+  // margin-top: 0.5rem;
+  // padding-bottom: 1.2rem;
+
+  margin-top: 1rem;
+  padding-bottom: 2rem;
+}
+</style>

--- a/src/views/AdminLayout/AdminLogin/index.vue
+++ b/src/views/AdminLayout/AdminLogin/index.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="container flex-fill py-4 py-lg-5 d-flex align-items-center">
+    <div class="w-100">
+      <div class="row g-3 g-lg-4 justify-content-evenly">
+        <div class="col-lg-5 align-self-lg-center">
+        </div>
+        <div class="col-lg-6">
+          <VForm class="card rounded-4 p-4 p-lg-5" v-slot="{ errors }" @submit="login">
+            <h1 class="h2 mb-3 text-center">管理者登入</h1>
+            <div class="form-floating mb-4">
+              <VField type="email" id="email" placeholder="請輸入電子信箱" name="信箱" class="form-control" :class="{ 'is-invalid': errors['信箱'] }" rules="email|required" v-model="user.email" />
+              <ErrorMessage name="信箱" class="invalid-feedback"/>
+              <label for="email">請輸入電子信箱</label>
+            </div>
+            <div class="form-floating mb-4">
+              <VField type="password" id="password" placeholder="請輸入密碼" name="密碼" class="form-control" :class="{ 'is-invalid': errors['密碼'] }" rules="required" v-model="user.password" />
+              <ErrorMessage name="密碼" class="invalid-feedback"/>
+              <label for="password">請輸入密碼</label>
+            </div>
+            <button type="submit" class="btn btn-brand-blue btn-lg rounded-pill mb-4">登入</button>
+          </VForm>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+export default {
+  data(){
+    return { 
+      user: {
+        email: '',
+        password: '',
+      },
+    }
+  },
+  methods:{
+    login(){
+      axios.post(`${import.meta.env.VITE_API}/admin/signin`, { username:this.user.email,password:this.user.password })
+        .then((res) => {
+          const token = res.data.token
+          const exp = res.data.expired
+          document.cookie = `token=${token}`
+          document.cookie = `expDate=${exp}`
+          this.$router.push(`/admin/admin-items`);
+      }).catch((error) => {
+      console.log(error)
+    })
+    }
+  },
+  async mounted() {
+  
+  }
+
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/AdminLayout/DeleteItemModal/index.vue
+++ b/src/views/AdminLayout/DeleteItemModal/index.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="modal fade" id="deleteItemModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel"
+    aria-hidden="true" ref="modalRef">
+    <div class="modal-dialog modal-xl" role="document">
+      <div class="modal-content border-0">
+        <div class="modal-header bg-danger text-white">
+          <h5 class="modal-title" id="exampleModalLabel">
+            您即將刪除
+          </h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <Warning style="width: 150px; height: 150px ;color:#fde4b4;"/>
+          <h3>確定要刪除"{{ item.title }}"嗎?</h3>
+          <h4 class="opacity-50">刪除後將無法復原，請務必確認!</h4>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-danger" data-bs-dismiss="modal" @click="$emit('deleteItem', item.id)">確定刪除</button>
+          <button type="button" class="btn btn-grey66" data-bs-dismiss="modal">取消</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Modal from 'bootstrap/js/dist/modal'
+import { Warning } from "@element-plus/icons-vue";
+export default {
+  props: {
+    item: {
+      type: Object,
+      default() {
+        return {};
+      },
+    },
+  },
+  data() {
+    return {
+      modal: '',
+    };
+  },
+  components: {
+    Warning
+  },
+  mounted() {
+    this.modal = new Modal(this.$refs.modalRef);
+  },
+  methods: {
+    openModal() {
+      this.modal.show();
+    },
+    hideModal() {
+      this.modal.hide();
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/views/AdminLayout/EditItem/index.vue
+++ b/src/views/AdminLayout/EditItem/index.vue
@@ -51,36 +51,21 @@
         <h5>營養比例(份)</h5>
         <div class="form-floating mb-4">
           <VField as="select" id="starchPortion" placeholder="請選擇澱粉比例" name="starchPortion" class="form-select" :class="{ 'is-invalid': errors['starchPortion'] }" rules="required" v-model="item.starchPortion">
-            <option value="0">0</option>
-            <option value="0.25">0.25</option>
-            <option value="0.33">0.33</option>
-            <option value="0.66">0.66</option>
-            <option value="0.75">0.75</option>
-            <option value="1">1</option>     
+            <option v-for="item in portionOptions" :value="item" :key="item">{{item}}</option>  
           </VField>
             <ErrorMessage name="starchPortion" class="invalid-feedback"/>
             <label for="starchPortion">澱粉比例*</label>
         </div>
         <div class="form-floating mb-4">
           <VField as="select" id="proteinPortion" placeholder="請選擇蛋白質比例" name="proteinPortion" class="form-select" :class="{ 'is-invalid': errors['proteinPortion'] }" rules="required" v-model="item.proteinPortion">
-            <option value="0">0</option>
-            <option value="0.25">0.25</option>
-            <option value="0.33">0.33</option>
-            <option value="0.66">0.66</option>
-            <option value="0.75">0.75</option>
-            <option value="1">1</option>   
+            <option v-for="item in portionOptions" :value="item" :key="item">{{item}}</option>  
           </VField>
             <ErrorMessage name="proteinPortion" class="invalid-feedback"/>
             <label for="proteinPortion">蛋白質比例*</label>
         </div>
         <div class="form-floating mb-4">
           <VField as="select" id="vegetablePortion" placeholder="請選擇蔬菜比例" name="vegetablePortion" class="form-select" :class="{ 'is-invalid': errors['vegetablePortion'] }" rules="required" v-model="item.vegetablePortion">
-            <option value="0">0</option>
-            <option value="0.25">0.25</option>
-            <option value="0.33">0.33</option>
-            <option value="0.66">0.66</option>
-            <option value="0.75">0.75</option>
-            <option value="1">1</option>    
+            <option v-for="item in portionOptions" :value="item" :key="item">{{item}}</option> 
           </VField>
             <ErrorMessage name="vegetablePortion" class="invalid-feedback"/>
             <label for="vegetablePortion">蔬菜比例*</label>
@@ -146,6 +131,7 @@ import { items } from '@/utils/variables'
 export default {
   data() {
     return {
+      portionOptions:[0,0.25,0.5,0.75,1,1.25,1.5,1.75,2,2.25,2.5,2.75,3,3.25,3.5,3.75,4,4.25,4.5,4.75,5],
       items,
       item: {
         title: '',

--- a/src/views/AdminLayout/EditItem/index.vue
+++ b/src/views/AdminLayout/EditItem/index.vue
@@ -1,0 +1,260 @@
+<template>
+  <div class="container my-5">
+    <div class="text-start mb-4 d-flex justify-content-between border-bottom pb-3">
+      <h3>編輯菜色</h3>
+      <button class="btn btn-outline-brand-blue">
+        <RouterLink class="navbar-brand" to="/admin/admin-items">
+          菜色列表
+        </RouterLink>
+      </button>
+    </div>
+    <VForm class="row" v-slot="{ errors }" @submit="editItem" >
+    <div class="p-2 p-lg-3 col-md-6">
+      <div>
+        <h5>菜色名稱 / 分類 / 健康分數</h5>
+        <div class="form-floating mb-4">
+          <VField type="text" id="title" placeholder="請輸入菜色名稱" name="title" class="form-control" :class="{ 'is-invalid': errors['title'] }" rules="required" v-model="item.title" />
+            <ErrorMessage name="title" class="invalid-feedback"/>
+            <label for="title">中文名稱*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField type="text" id="engTitle" placeholder="請輸入英文名稱" name="engTitle" class="form-control" :class="{ 'is-invalid': errors['engTitle'] }" rules="required" v-model="item.engTitle" />
+            <ErrorMessage name="engTitle" class="invalid-feedback"/>
+            <label for="engTitle">英文名稱*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="category" placeholder="請選擇分類" name="category" class="form-select" :class="{ 'is-invalid': errors['category'] }" rules="required" v-model="item.category">
+            <option value="主食類">主食類</option>
+            <option value="配菜類">配菜類</option>
+            <option value="主菜類">主菜類</option>
+          </VField>
+            <ErrorMessage name="category" class="invalid-feedback"/>
+            <label for="category">分類*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="healthLevel" placeholder="請選擇健康分數" name="healthLevel" class="form-select" :class="{ 'is-invalid': errors['healthLevel'] }" rules="required" v-model="item.healthLevel">
+            <option value="1">1</option>
+            <option value="1.5">1.5</option>
+            <option value="2">2</option>
+            <option value="2.5">2.5</option>
+            <option value="3">3</option>
+            <option value="3.5">3.5</option>
+            <option value="4">4</option>  
+            <option value="4.5">4.5</option>
+            <option value="5">5</option>   
+          </VField>
+            <ErrorMessage name="healthLevel" class="invalid-feedback"/>
+            <label for="healthLevel">健康分數*</label>
+        </div>
+      </div>
+      <div>
+        <h5>營養比例(份)</h5>
+        <div class="form-floating mb-4">
+          <VField as="select" id="starchPortion" placeholder="請選擇澱粉比例" name="starchPortion" class="form-select" :class="{ 'is-invalid': errors['starchPortion'] }" rules="required" v-model="item.starchPortion">
+            <option value="0">0</option>
+            <option value="0.25">0.25</option>
+            <option value="0.33">0.33</option>
+            <option value="0.66">0.66</option>
+            <option value="0.75">0.75</option>
+            <option value="1">1</option>     
+          </VField>
+            <ErrorMessage name="starchPortion" class="invalid-feedback"/>
+            <label for="starchPortion">澱粉比例*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="proteinPortion" placeholder="請選擇蛋白質比例" name="proteinPortion" class="form-select" :class="{ 'is-invalid': errors['proteinPortion'] }" rules="required" v-model="item.proteinPortion">
+            <option value="0">0</option>
+            <option value="0.25">0.25</option>
+            <option value="0.33">0.33</option>
+            <option value="0.66">0.66</option>
+            <option value="0.75">0.75</option>
+            <option value="1">1</option>   
+          </VField>
+            <ErrorMessage name="proteinPortion" class="invalid-feedback"/>
+            <label for="proteinPortion">蛋白質比例*</label>
+        </div>
+        <div class="form-floating mb-4">
+          <VField as="select" id="vegetablePortion" placeholder="請選擇蔬菜比例" name="vegetablePortion" class="form-select" :class="{ 'is-invalid': errors['vegetablePortion'] }" rules="required" v-model="item.vegetablePortion">
+            <option value="0">0</option>
+            <option value="0.25">0.25</option>
+            <option value="0.33">0.33</option>
+            <option value="0.66">0.66</option>
+            <option value="0.75">0.75</option>
+            <option value="1">1</option>    
+          </VField>
+            <ErrorMessage name="vegetablePortion" class="invalid-feedback"/>
+            <label for="vegetablePortion">蔬菜比例*</label>
+        </div>
+      </div>
+    </div>
+    <div class="p-2 p-lg-3 col-md-6">
+      <div>
+        <h5>菜色圖片</h5>
+        <form id="upload-image" class="mb-2" action="/api/whatstoday2024/admin/upload" enctype="multipart/form-data" method="post">
+          <label for="formFile" class="form-label">上傳圖片</label>
+          <input ref="input-file" class="form-control" type="file" id="file-input" name="file-to-upload" @change="uploadImg">
+          <!-- <input type="submit" value="送出" @click.prevent="uploadImg"> -->
+          <img v-if="tempImg1 !==''" class="img" :src="tempImg1" alt="image">
+          <button v-if="tempImg1 !== ''" type="button" @click="addImage1" class="mt-2 btn btn-outline-brand-blue btn-sm">新增此圖片至圖片列表</button>
+        </form>
+      </div>
+      <div>
+        <div class="form-floating mb-4">
+          <div class="form-group mb-3">
+            <label for="imgUrl" class="form-label">圖片網址</label>
+              <input id="imgUrl" v-model="tempImg2" type="text" class="form-control" placeholder="請輸入圖片連結">
+              <img v-if="tempImg2 !==''" class="img" :src="tempImg2" alt="image">
+              <button v-if="tempImg2 !== ''" type="button" @click="addImage2" class="mt-2 btn btn-outline-brand-blue btn-sm">新增此圖片至圖片列表</button>
+          </div>
+        </div> 
+      </div>
+      <div>
+        <div class="mb-3">
+          <span>主圖*</span><span class="errorMsg">{{ errorMsg }}</span>
+          <div v-if="item.imgUrl">
+            <img class="img" :src="item.imgUrl" alt="image">
+          </div>
+        </div>
+        <div mb-3>
+          <span>圖片列表(點選<ElSelect style="width: 20px; height: 20px ;color:yellow;"/>成為主圖 / <DeleteFilled style="width: 20px; height: 20px ;color:black;"/>刪除圖片)</span>
+          <div v-if="item?.images?.length" class="img-box">
+            <div v-for="(img,index) in item.images" :key="index" style="position: relative;">
+              <img class="img" :src="img" alt="image">
+              <span @click="chooseMainImg(img)"><ElSelect style="width: 30px; height: 30px ;color:yellow; position: absolute; top: 1; left: 1;cursor: pointer;"/></span>
+              <span @click="deleteImg(index)"><DeleteFilled style="width: 30px; height: 30px ;color:#d4d4d4; position: absolute; top: 1; right: 1;cursor: pointer;"/></span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="d-flex gap-2 mt-3 btn-container">
+        <button type="submit" class="btn btn-brand-blue btn-md mb-4">確認</button>
+      </div>
+      
+    </div>
+        
+    </VForm>
+  </div>
+</template>
+
+<script>
+import { toast } from 'vue3-toastify';
+import 'vue3-toastify/dist/index.css';
+import axios from 'axios'
+import { DeleteFilled } from "@element-plus/icons-vue";
+import { Select as ElSelect } from "@element-plus/icons-vue";
+import { items } from '@/utils/variables'
+export default {
+  data() {
+    return {
+      items,
+      item: {
+        title: '',
+        engTitle: '',
+        category:'',
+        healthLevel:'',
+        starchPortion: '',
+        proteinPortion: '',
+        vegetablePortion: '',
+        imgUrl: '',
+        images:[],
+        noBgImg: ''
+      },
+      tempImg1:'',
+      tempImg2:'',
+      errorMsg:'',
+    }
+  },
+  components: {
+    DeleteFilled,
+    ElSelect
+  },
+  methods: {
+    uploadImg() {
+          // 取出 Token
+        const form = document.querySelector('#upload-image');
+        const imageInput = document.querySelector("#file-input");
+        const formData = new FormData(form);
+        if (imageInput.value) {
+            const token = document.cookie.replace(/(?:(?:^|.*;\s*)token\s*=\s*([^;]*).*$)|^.*$/, '$1');
+            axios.defaults.headers.common.Authorization = token;
+            axios.post(`${import.meta.env.VITE_API}/api/${import.meta.env.VITE_PATH}/admin/upload`, formData)
+                .then((res) => {
+                    this.tempImg1 = res.data.imageUrl;
+                    imageInput.value = '';
+                    axios.defaults.headers.common.Authorization = null;
+                })
+                .catch(err => {
+                    alert(err.data.message);
+                    axios.defaults.headers.common.Authorization = null;
+                })
+        } else {
+            alert("請先選擇欲上傳之圖片。");
+            axios.defaults.headers.common.Authorization = null;
+        }
+    },
+    async editItem(){
+      if(this.item.imgUrl === ''){
+        this.errorMsg = '主圖為必填'
+        return
+      }
+      try{
+        const res = await axios.patch(`http://localhost:3000/items/${this.item.id}`,this.item)
+        console.log(res)
+        toast.success("成功編輯菜色");
+        // toast.success(res.data.message);
+      }catch(err){
+        toast.error(err.data.message);
+      }
+      
+    },
+    addImage1(){
+      this.item.images.push(this.tempImg1)
+      this.tempImg1 = ''
+    },
+    addImage2(){
+      this.item.images.push(this.tempImg2)
+      this.tempImg2 = ''
+    },
+    chooseMainImg(img){
+      this.item.imgUrl = img
+    },
+    deleteImg(index){
+      this.item.images.splice(index,1)
+    }
+  },
+  watch:{
+    'item.imgUrl':function(){
+      this.errorMsg = ''
+    },
+  },
+  async mounted() {
+    const id = this.$route.params.id
+    const res = await axios.get(`http://localhost:3000/items/${id}`)
+    console.log(res.data)
+    this.item = res.data
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.img-box{
+  display: flex;
+}
+.img{
+  width: 12rem;
+}
+
+.container{
+  position: relative;
+}
+.btn-container{
+  position: absolute;
+  top: 3.5rem;
+  right: 0.8rem;
+}
+.errorMsg{
+  color: $brand-red;
+  font-size: 0.9rem;
+  margin-left: 1rem;
+}
+</style>

--- a/src/views/AdminLayout/index.vue
+++ b/src/views/AdminLayout/index.vue
@@ -1,11 +1,14 @@
 <template>
-  <div> 管理者頁面的主LAYOUT </div>
+  <RouterView></RouterView>
 </template>
 
 <script>
-export default {
-
-}
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.btns{
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+</style>

--- a/src/views/HomeView/MemberSection.vue
+++ b/src/views/HomeView/MemberSection.vue
@@ -2,7 +2,7 @@
   <section class="member-section table-img">
     <h1 class="section-title fw-bold">成為會員，您可以...</h1>
     <!-- <div class="d-flex justify-content-around "> -->
-    <div class="row section">
+    <div class="row">
       <div class="col-6 col-lg-3 g-5 d-flex flex-column align-items-center" v-for="(option, index) in  memberOptions " :key="option.id">
         <div class="option-item relative" :style="isShow === option.id ? obj : ''" @click="showDetail(option.id)">
           <div class="d-flex flex-column gap-1 align-items-center">
@@ -19,7 +19,7 @@
     </div>
     <div class="text-center">
       <router-link to="/register" class="btn btn-lg btn-brand-blue text-white rounded-pill">
-        <span>成為會員 &#62;</span>
+        <div class="d-flex align-items-center">成為會員 <ArrowRightBold style="width: 20px; height: 20px ;color:white;;"/></div>
       </router-link>
     </div>
   </section>
@@ -28,6 +28,7 @@
 <script>
 import { memberOptions } from '@/utils/variables'
 import tableImg from '@/assets/img/table.png'
+import { CaretLeft, CaretRight, ArrowRightBold } from "@element-plus/icons-vue";
 
 export default {
   data() {
@@ -38,6 +39,11 @@ export default {
       obj: { transform: 'translateY(-120px)' }
     }
   },
+  components: {
+    CaretRight,
+    CaretLeft,
+    ArrowRightBold
+},
   methods: {
     showDetail(id) {
       this.isShow = id
@@ -51,14 +57,14 @@ export default {
 .member-section {
   width: 100vw;
   display: flex;
-  gap: 6.25rem;
+  gap: 5rem;
   flex-direction: column;
   justify-content: center;
-  margin-bottom: 6.25rem;
+  // margin-bottom: 6.25rem;
 }
 
 .section-title {
-  margin-left: 6rem;
+  margin-left: 2rem;
 
   @include respond(xl) {
     margin-left: 2rem;
@@ -73,7 +79,11 @@ export default {
   background-image: url('@/assets/img/table.png');
   background-repeat: no-repeat;
   background-position: 0% 30%;
-  background-size: 80%;
+
+
+  @include respond(lg) {
+
+  }
 
   @include respond(md) {
     background-position: 0% 20%;

--- a/src/views/HomeView/ProvideSection.vue
+++ b/src/views/HomeView/ProvideSection.vue
@@ -10,12 +10,17 @@
             <div class="col-10">
               <h3 class="fw-bold">{{ item.title }}</h3>
               <h6>{{ item.content }}</h6></div>
-            </div>
+          </div>
+          <div class="text-start mt-4">
+            <router-link to="/register" class="btn btn-lg btn-brand-blue text-white rounded-pill">
+              <div class="d-flex align-items-center">立即開始 <ArrowRightBold style="width: 20px; height: 20px ;color:white;;"/></div>
+            </router-link>
+          </div>
         </div>
       </div>
       <div class="d-none d-lg-block col-12 col-lg-5">
         <div class="card-right">
-          <img class="img object-fit-cover" :src="eatingImg" alt="eating">
+          <img class="img" :src="eatingImg" alt="eating">
         </div>
       </div>
     </div>
@@ -26,6 +31,8 @@
 import eatingImg from '@/assets/img/sloution_person.png'
 import { provideOptions } from '@/utils/variables'
 import axios from 'axios'
+import { CaretLeft, CaretRight, ArrowRightBold } from "@element-plus/icons-vue";
+
 export default {
   data() {
     return {
@@ -33,21 +40,14 @@ export default {
       provideOptions,
     }
   },
+  components: {
+    CaretRight,
+    CaretLeft,
+    ArrowRightBold
+},
   computed: {
     classObject: () => {}
   },
-  async mounted() {
-    const res = await axios.patch('http://localhost:3000/items/59ee', {
-      "title": "蔥爆牛肉555",
-      "eng": "Stir-fried Beef with Scallions2",
-      "healthLevel": 4.5,
-      "starchLevel": 0,
-      "proteinLevel": 0.25,
-      "vegLevel": 0.5,
-      "img": "https://res.cloudinary.com/dfvtounam/image/upload/v1707714590/%E8%9E%A2%E5%B9%95%E6%93%B7%E5%8F%96%E7%95%AB%E9%9D%A2_2024-02-12_130924_mbdgp0.png"
-    })
-    console.log(res)
-  }
 }
 </script>
 
@@ -69,6 +69,11 @@ export default {
 
 .icon {
   width: 60px;
+}
+
+.img{
+  object-fit: fill;
+  height: 100vh;
 }
 
 .card-right {

--- a/src/views/HomeView/QAsection.vue
+++ b/src/views/HomeView/QAsection.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="section">
     <div class="card bg-primary-mid">
-      <div class="card-body d-flex justify-content-between">
-        <h2 class="card-title fw-bold card-left">常見問題</h2>
+      <div class="card-body d-lg-flex justify-content-between">
+        <h3 class="card-title fw-bold card-left mb-4">常見問題</h3>
         <div class="accordion" id="myAccordion">
           <div v-for="(item, index) in items" :key="index" class="accordion-item">
             <h2 class="accordion-header" :id="'heading' + index">
@@ -31,6 +31,9 @@ export default {
   },
   methods: {
     toggleAccordion(index) {
+      if(index === this.activeItem){
+        return
+      }
       this.activeItem = this.activeItem === index ? null : index;
     },
   },
@@ -46,5 +49,12 @@ export default {
   background-repeat: no-repeat;
   // background-position: start;
   background-size: contain;
+}
+
+.accordion{
+  width: 77%;
+}
+.accordion-item{
+  width: 100%;
 }
 </style>

--- a/src/views/temp.vue
+++ b/src/views/temp.vue
@@ -1,0 +1,23 @@
+<template>
+  <section class="">
+   
+  </section>
+</template>
+
+<script>
+
+
+export default {
+  data() {
+    return {
+    
+    }
+  },
+  methods: {
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>


### PR DESCRIPTION
新增:
1.增加後臺菜色頁面
2.增加後臺菜色編輯頁面
3.增加後臺新增菜色頁面
4.刪除菜色功能(彈窗)
5.菜色頁面多頁功能
6.增加後臺登入頁面
7.以上 api 功能皆已完成，但目前只用了本地的json-server測試，待adonis大將json-server部屬

調整:
1.新增及調整按鈕
2.修改文字正確性
3.調整QA邏輯讓永遠都有一個問答開啟 / rwd 排版 / 問答的文案正確性
4.調整成為會員section的排版