### PR TITLE
Modify: 調整eslint規則，以避免index.vue觸發檔名沒有多個字的錯誤

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,5 +27,12 @@ module.exports = {
     'vue'
   ],
   rules: {
+    'vue/multi-word-component-names': [
+      'error',
+      {
+        ignores: ['index']
+      }
+    ]
+
   }
 }


### PR DESCRIPTION
Modify: 調整eslint規則，以避免index.vue觸發檔名沒有多個字的錯誤